### PR TITLE
fix: memory leak caused by log4sp::GetScriptedLoc

### DIFF
--- a/extern/spdlog/include/spdlog/pattern_formatter-inl.h
+++ b/extern/spdlog/include/spdlog/pattern_formatter-inl.h
@@ -693,18 +693,15 @@ public:
     #pragma warning(disable : 4127)  // consider using 'if constexpr' instead
 #endif                               // _MSC_VER
     static const char *basename(const char *filename) {
-        // if the size is 2 (1 character + null terminator) we can use the more efficient strrchr
-        // the branch will be elided by optimizations
-        if (sizeof(os::folder_seps) == 2) {
-            const char *rv = std::strrchr(filename, os::folder_seps[0]);
-            return rv != nullptr ? rv + 1 : filename;
+        //* Log4sp customization *//
+        // 先后顺序很重要，即使大部分插件是在 windows 下编译的
+        // 原因: '/' 是 Win 的特殊字符 , 但 '\' 不是 Linux 的特殊字符
+        const char *rv = std::strrchr(filename, '/');
+        if (rv != nullptr) {
+            return rv + 1;
         } else {
-            const std::reverse_iterator<const char *> begin(filename + std::strlen(filename));
-            const std::reverse_iterator<const char *> end(filename);
-
-            const auto it = std::find_first_of(begin, end, std::begin(os::folder_seps),
-                                               std::end(os::folder_seps) - 1);
-            return it != end ? it.base() : filename;
+            const char *rv = std::strrchr(filename, '\\');
+            return rv != nullptr ? rv + 1 : filename;
         }
     }
 #ifdef _MSC_VER

--- a/sourcemod/scripting/log4sp-test.sp
+++ b/sourcemod/scripting/log4sp-test.sp
@@ -119,8 +119,8 @@ void TestLoggerLog(Logger logger)
     logger.LogSrc(LogLevel_Debug, "Test log message 3.");
     logger.LogSrcAmxTpl(LogLevel_Info, "Test log message %d.", 4);
 
-    logger.LogLoc("testFile5.log", 5, "testFunc5", LogLevel_Warn, "Test log message 5.");
-    logger.LogLocAmxTpl("testFile6.log", 6, "testFunc6", LogLevel_Fatal, "Test log message %d.", 6);
+    logger.LogLoc("/home/sm-ext-log4sp/Linux-testFile5.log", 5, "testFunc5", LogLevel_Warn, "Test log message 5.");
+    logger.LogLocAmxTpl("C:\\user\\sm-ext-log4sp\\Win-testFile6.log", 6, "testFunc6", LogLevel_Fatal, "Test log message %d.", 6);
 
     logger.Trace("Test log message 7.");
     logger.TraceAmxTpl("Test log message %d.", 8);

--- a/src/log4sp/common.cpp
+++ b/src/log4sp/common.cpp
@@ -163,35 +163,6 @@ spdlog::level::level_enum CellToLevelOrLogWarn(IPluginContext *ctx, cell_t lvl)
 }
 
 /**
- * 将 path 路径分隔符全部替换为
- * 与 log4sp extension 编译的平台相同的分隔符
- * 返回替换后的字符串
- */
-char *ReplacePathSep(const char *path)
-{
-    int len = strlen(path);
-    char *result = new char[len + 1];
-
-    // 与 spdlog 源码类似，Win、Linux 双平台分开处理
-    if (sizeof(spdlog::details::os::folder_seps) == 2)
-    {
-        for (int i = 0; i < len; ++i)
-        {
-            result[i] = path[i] == '\\' ? '/' : path[i];
-        }
-    }
-    else
-    {
-        for (int i = 0; i < len; ++i)
-        {
-            result[i] = path[i] == '/' ? '\\' : path[i];
-        }
-    }
-    result[len] = '\0';
-    return result;
-}
-
-/**
  * 返回 Scripted 调用 log4sp extension natives 的代码位置
  * 如果找不到，输出一条警告信息
  * 并返回空
@@ -199,54 +170,23 @@ char *ReplacePathSep(const char *path)
 spdlog::source_loc GetScriptedLoc(IPluginContext *ctx)
 {
     SourcePawn::IFrameIterator *frames = ctx->CreateFrameIterator();
-    for (int i = 1; !frames->Done(); ++i)
+
+    for (; !frames->Done(); frames->Next())
     {
-        if (!frames->IsScriptedFrame() || !strncmp(frames->FilePath(), "log4sp", 6))
+        if (frames->IsScriptedFrame())
         {
-            frames->Next(); // 当前栈帧不是插件调用的栈帧，我们需要继续向下查找
-            // SPDLOG_TRACE("i={} | IsInternal={} | IsNative={} | IsScripted={} | file={} | func={} | line={}",
-            //     ++i,
-            //     frames->IsInternalFrame(),
-            //     frames->IsNativeFrame(),
-            //     frames->IsScriptedFrame(),
-            //     frames->FilePath() == nullptr ? "null": frames->FilePath(),
-            //     frames->FunctionName() == nullptr ? "null": frames->FunctionName(),
-            //     frames->LineNumber()
-            // );
-        }
-        else
-        {
-            break;          // 符合条件, 说明当前栈帧是用户调用 log4sp api 的 frame
+            const char *file = frames->FilePath();
+            const char *func = frames->FunctionName();
+            int line = frames->LineNumber();
+            ctx->DestroyFrameIterator(frames); // 千万不要忘记
+
+            return spdlog::source_loc(file, line, func);
         }
     }
 
-    if (frames->Done())
-    {
-        ctx->DestroyFrameIterator(frames);
-        spdlog::warn("Scripted source location not found, fix to empty.");
-        // spdlog::dump_backtrace();
-        return {};
-    }
-
-    const char *file = frames->FilePath();
-    const char *func = frames->FunctionName();
-    const int line = frames->LineNumber();
-    ctx->DestroyFrameIterator(frames);
-
-    /**
-     * Bug：
-     *      在 Pattern 中添加 %s 来显示文件名时，日志消息总是附带是完整的 path 而不是仅输出文件名
-     * Description：
-     *      如果 extension 编译时所用的操作系统和 plugin 编译时所用的操作系统不同
-     *      则 pattern 的 %s 只能显示完整的路径名, 而不是只显示文件名
-     * Reason：
-     *      spdlog 中的 short_filename_formatter::basename 通过判断 spdlog::details::os::folder_seps
-     *      来决定从 path 中截取文件名的方案，这导致 spdlog 无法识别其他操作系统的 path 中的分隔符
-     * Slove:
-     *      1. 传递 path 给 spdlog 前，将分隔符替换为 short_filename_formatter::basename 匹配的分隔符
-     *      2. 更新 spdlog 为 v2.x 版本 (不采用！因为 v2.x 似乎不够完善, 并且活跃度较低)
-     */
-    return spdlog::source_loc(ReplacePathSep(file), line, func);
+    ctx->DestroyFrameIterator(frames); // 千万不要忘记
+    spdlog::warn("Scripted source location not found, fix to empty.");
+    return {};
 }
 
 /**

--- a/src/log4sp/common.h
+++ b/src/log4sp/common.h
@@ -36,8 +36,6 @@ bool CellToLevel(cell_t lvl, spdlog::level::level_enum &result);
 
 spdlog::level::level_enum CellToLevelOrLogWarn(IPluginContext *ctx, cell_t lvl);
 
-// char *ReplacePathSep(const char *path);
-
 spdlog::source_loc GetScriptedLoc(IPluginContext *ctx);
 
 char *FormatToAmxTplString(SourcePawn::IPluginContext *ctx, const cell_t *params, unsigned int param);


### PR DESCRIPTION
### 问题起源

- 若 log4sp 编译时所在的操作系统与插件编译时所在的操作系统不同，则 pattern 的 %s (short filename) 总会显示完整路径，而不是预期中只显示路径末尾的文件名。

### 早期解决方案

- 未采用的方案

  使用 spdlog v2.x。 但 v2.x 的近期活跃度偏低，且实际上升级到 v2.x 也不能解决此问题

- 实际采用的方案

  使用 log4sp::ReplacePathSep 将传入的路径分隔符替换为 log4sp 编译时所在的操作系统的分隔符，其中替换后的字符串是 new 出来的，但并没有在合适的时候回收，所以存在内存泄漏

  可以不修改源码，修复此方案的内存泄漏继续解决这个问题
  但略麻烦，所以此补丁选择了更改 spdlog 的 short_filename_formatter::basename 源码

### 新的解决方案
  
- 编译时不再按编译时所运行的操作系统直接写死分隔符， 而是每次都先查找 '/' 分隔符，如果没找到；再查找 '\' 分隔符，从而得到路径末尾的文件名

- 其中查找顺序很重要

  '/' 是 Windows 的特殊字符
  '\' 不是 Linux 的特殊字符

- 此方案已知的唯一缺点是

  在最不理想的情况下，需要遍历两次路径字符串 (路径最大长度 260) 且很多 plugins 都是在 win 中编译的，这些 plugin 都需要遍历两次

  