### PR TITLE
Add macro LOG4SP_NO_LOG

### DIFF
--- a/sourcemod/scripting/include/log4sp.inc
+++ b/sourcemod/scripting/include/log4sp.inc
@@ -7,6 +7,17 @@
 #pragma semicolon 1
 
 
+
+/**
+ * Define LOG4SP_NO_LOG before including this file to replace all log4sp apis with empty statements.
+ * This can make the plugin no require log4sp extension
+ */
+// #define LOG4SP_NO_LOG
+
+
+
+#if !defined LOG4SP_NO_LOG
+
 #include <log4sp/common>
 #include <log4sp/logger>
 #include <log4sp/sinks/sink>
@@ -16,6 +27,18 @@
 #include <log4sp/sinks/daily_file_sink>
 #include <log4sp/sinks/client_console_sink>
 
+#else
+
+#include <log4sp_empty/common>
+#include <log4sp_empty/logger>
+#include <log4sp_empty/sinks/sink>
+#include <log4sp_empty/sinks/server_console_sink>
+#include <log4sp_empty/sinks/base_file_sink>
+#include <log4sp_empty/sinks/rotating_file_sink>
+#include <log4sp_empty/sinks/daily_file_sink>
+#include <log4sp_empty/sinks/client_console_sink>
+
+#endif
 
 
 
@@ -31,12 +54,12 @@ public Extension __ext_log4sp =
 {
     name = "Logging for SourcePawn",
     file = "log4sp.ext",
-#if defined AUTOLOAD_EXTENSIONS
+#if defined AUTOLOAD_EXTENSIONS && !defined LOG4SP_NO_LOG
     autoload = 1,
 #else
     autoload = 0,
 #endif
-#if defined REQUIRE_EXTENSIONS
+#if defined REQUIRE_EXTENSIONS && !defined LOG4SP_NO_LOG
     required = 1,
 #else
     required = 0,

--- a/sourcemod/scripting/include/log4sp_empty/common.inc
+++ b/sourcemod/scripting/include/log4sp_empty/common.inc
@@ -1,0 +1,74 @@
+#if defined _log_for_sourcepawn_common_included
+ #endinput
+#endif
+#define _log_for_sourcepawn_common_included
+
+#pragma newdecls required
+#pragma semicolon 1
+
+#define LOG4SP_LEVEL_TRACE              0
+#define LOG4SP_LEVEL_DEBUG              1
+#define LOG4SP_LEVEL_INFO               2
+#define LOG4SP_LEVEL_WARN               3
+#define LOG4SP_LEVEL_ERROR              4
+#define LOG4SP_LEVEL_FATAL              5
+#define LOG4SP_LEVEL_OFF                6
+
+#define LOG4SP_LEVEL_NAME_TRACE         "trace"
+#define LOG4SP_LEVEL_NAME_DEBUG         "debug"
+#define LOG4SP_LEVEL_NAME_INFO          "info"
+#define LOG4SP_LEVEL_NAME_WARN          "warn"
+#define LOG4SP_LEVEL_NAME_ERROR         "error"
+#define LOG4SP_LEVEL_NAME_FATAL         "fatal"
+#define LOG4SP_LEVEL_NAME_OFF           "off"
+
+#define LOG4SP_LEVEL_SHORT_NAME_TRACE   "T"
+#define LOG4SP_LEVEL_SHORT_NAME_DEBUG   "D"
+#define LOG4SP_LEVEL_SHORT_NAME_INFO    "I"
+#define LOG4SP_LEVEL_SHORT_NAME_WARN    "W"
+#define LOG4SP_LEVEL_SHORT_NAME_ERROR   "E"
+#define LOG4SP_LEVEL_SHORT_NAME_FATAL   "F"
+#define LOG4SP_LEVEL_SHORT_NAME_OFF     "O"
+
+
+/**
+ * Log level enum
+ */
+enum LogLevel
+{
+    LogLevel_Trace = LOG4SP_LEVEL_TRACE,
+    LogLevel_Debug = LOG4SP_LEVEL_DEBUG,
+    LogLevel_Info  = LOG4SP_LEVEL_INFO,
+    LogLevel_Warn  = LOG4SP_LEVEL_WARN,
+    LogLevel_Error = LOG4SP_LEVEL_ERROR,
+    LogLevel_Fatal = LOG4SP_LEVEL_FATAL,
+    LogLevel_Off   = LOG4SP_LEVEL_OFF,
+    LogLevel_Total
+}
+
+/**
+ * Pattern time - specific time getting to use for pattern_formatter.
+ * local time by default
+ */
+enum PatternTimeType
+{
+    PatternTimeType_Local,              // log localtime
+    PatternTimeType_Utc                 // log utc
+};
+
+/**
+ * Async overflow policy - block by default.
+ */
+enum AsyncOverflowPolicy
+{
+    AsyncOverflowPolicy_Block,          // Block until message can be enqueued.
+    AsyncOverflowPolicy_OverrunOldest,  // Discard oldest message in the queue if full when trying to add new item.
+    AsyncOverflowPolicy_DiscardNew      // Discard new message if the queue is full when trying to add new item.
+}
+
+
+stock void LogLevelToName(LogLevel lvl, char[] buffer, int maxlen) {}
+
+stock void LogLevelToShortName(LogLevel lvl, char[] buffer, int maxlen) {}
+
+stock LogLevel NameToLogLevel(const char[] name) { return LogLevel_Off; }

--- a/sourcemod/scripting/include/log4sp_empty/logger.inc
+++ b/sourcemod/scripting/include/log4sp_empty/logger.inc
@@ -1,0 +1,91 @@
+#if defined _log_for_sourcepawn_logger_included
+ #endinput
+#endif
+#define _log_for_sourcepawn_logger_included
+
+#pragma newdecls required
+#pragma semicolon 1
+
+#include <log4sp_empty/common>
+#include <log4sp_empty/sinks/sink>
+
+
+typeset Log4spErrorCallback
+{
+    function void (const char[] msg);
+};
+
+methodmap Logger < Handle
+{
+    public Logger(const char[] name, Sink[] sinks, int numSinks, bool async=false, AsyncOverflowPolicy policy=AsyncOverflowPolicy_Block) { return view_as<Logger>(INVALID_HANDLE); }
+
+    public static Logger Get(const char[] name) { return view_as<Logger>(INVALID_HANDLE); }
+
+    public static Logger CreateServerConsoleLogger(const char[] name, bool async=false, AsyncOverflowPolicy policy=AsyncOverflowPolicy_Block) { return view_as<Logger>(INVALID_HANDLE); }
+
+    public static Logger CreateBaseFileLogger(const char[] name, const char[] file, bool truncate=false, bool async=false, AsyncOverflowPolicy policy=AsyncOverflowPolicy_Block) { return view_as<Logger>(INVALID_HANDLE); }
+
+    public static Logger CreateRotatingFileLogger(const char[] name, const char[] file, int maxFileSize, int maxFiles, bool rotateOnOpen=false, bool async=false, AsyncOverflowPolicy policy=AsyncOverflowPolicy_Block) { return view_as<Logger>(INVALID_HANDLE); }
+
+    public static Logger CreateDailyFileLogger(const char[] name, const char[] file, int hour=0, int minute=0, bool truncate=false, int maxFiles=0, bool async=false, AsyncOverflowPolicy policy=AsyncOverflowPolicy_Block) { return view_as<Logger>(INVALID_HANDLE); }
+
+    public void GetName(char[] buffer, int maxlen) {}
+
+    public LogLevel GetLevel() { return LogLevel_Off; }
+
+    public void SetLevel(LogLevel lvl) {}
+
+    public void SetPattern(const char[] pattern, PatternTimeType type=PatternTimeType_Local) {}
+
+    public bool ShouldLog(LogLevel lvl) { return false; }
+
+    public void Log(LogLevel lvl, const char[] msg) {}
+    public void LogAmxTpl(LogLevel lvl, const char[] fmt, any ...) {}
+    // public void LogFmtTpl(LogLevel lvl, const char[] fmt, any ...) {}
+
+    public void LogSrc(LogLevel lvl, const char[] msg) {}
+    public void LogSrcAmxTpl(LogLevel lvl, const char[] fmt, any ...) {}
+    // public void LogSrcFmtTpl(LogLevel lvl, const char[] fmt, any ...) {}
+
+    public void LogLoc(const char[] file, int line, const char[] func, LogLevel lvl, const char[] msg) {}
+    public void LogLocAmxTpl(const char[] file, int line, const char[] func, LogLevel lvl, const char[] fmt, any ...) {}
+    // public void LogLocFmtTpl(const char[] file, int line, const char[] func, LogLevel lvl, const char[] fmt, any ...) {}
+
+    public void Trace(const char[] msg) {}
+    public void TraceAmxTpl(const char[] fmt, any ...) {}
+    // public void TraceFmtTpl(const char[] fmt, any ...) {}
+
+    public void Debug(const char[] msg) {}
+    public void DebugAmxTpl(const char[] fmt, any ...) {}
+    // public void DebugFmtTpl(const char[] fmt, any ...) {}
+
+    public void Info(const char[] msg) {}
+    public void InfoAmxTpl(const char[] fmt, any ...) {}
+    // public void InfoFmtTpl(const char[] fmt, any ...) {}
+
+    public void Warn(const char[] msg) {}
+    public void WarnAmxTpl(const char[] fmt, any ...) {}
+    // public void WarnFmtTpl(const char[] fmt, any ...) {}
+
+    public void Error(const char[] msg) {}
+    public void ErrorAmxTpl(const char[] fmt, any ...) {}
+    // public void ErrorFmtTpl(const char[] fmt, any ...) {}
+
+    public void Fatal(const char[] msg) {}
+    public void FatalAmxTpl(const char[] fmt, any ...) {}
+    // public void FatalFmtTpl(const char[] fmt, any ...) {}
+
+    public void Flush() {}
+    public LogLevel GetFlushLevel() { return LogLevel_Off; }
+    public void FlushOn(LogLevel lvl) {}
+
+    public bool ShouldBacktrace() { return false; }
+    public void EnableBacktrace(int num) {}
+    public void DisableBacktrace() {}
+    public void DumpBacktrace() {}
+
+    public void AddSink(Sink sink) {}
+    public bool DropSink(Sink sink) { return false; }
+
+    public void SetErrorHandler(Log4spErrorCallback callback) {}
+}

--- a/sourcemod/scripting/include/log4sp_empty/logger.inc
+++ b/sourcemod/scripting/include/log4sp_empty/logger.inc
@@ -51,6 +51,10 @@ methodmap Logger < Handle
     public void LogLocAmxTpl(const char[] file, int line, const char[] func, LogLevel lvl, const char[] fmt, any ...) {}
     // public void LogLocFmtTpl(const char[] file, int line, const char[] func, LogLevel lvl, const char[] fmt, any ...) {}
 
+    public void LogStackTrace(LogLevel lvl, const char[] msg) {}
+    public void LogStackTraceAmxTpl(LogLevel lvl, const char[] msg, any ...) {}
+    // public void LogStackTraceFmtTpl(LogLevel lvl, const char[] msg, any ...) {}
+
     public void Trace(const char[] msg) {}
     public void TraceAmxTpl(const char[] fmt, any ...) {}
     // public void TraceFmtTpl(const char[] fmt, any ...) {}

--- a/sourcemod/scripting/include/log4sp_empty/sinks/base_file_sink.inc
+++ b/sourcemod/scripting/include/log4sp_empty/sinks/base_file_sink.inc
@@ -1,0 +1,25 @@
+#if defined _log_for_sourcepawn_sinks_base_file_sink_included
+ #endinput
+#endif
+#define _log_for_sourcepawn_sinks_base_file_sink_included
+
+#pragma newdecls required
+#pragma semicolon 1
+
+#include <log4sp_empty/sinks/sink>
+
+
+methodmap BaseFileSinkST < Sink
+{
+    public BaseFileSinkST(const char[] file, bool truncate = false) { return view_as<BaseFileSinkST>(INVALID_HANDLE); }
+
+    public void GetFilename(char[] buffer, int maxlen) {}
+}
+
+
+methodmap BaseFileSinkMT < Sink
+{
+    public BaseFileSinkMT(const char[] file, bool truncate = false) { return view_as<BaseFileSinkMT>(INVALID_HANDLE); }
+
+    public void GetFilename(char[] buffer, int maxlen) {}
+}

--- a/sourcemod/scripting/include/log4sp_empty/sinks/client_console_sink.inc
+++ b/sourcemod/scripting/include/log4sp_empty/sinks/client_console_sink.inc
@@ -1,0 +1,34 @@
+#if defined _log_for_sourcepawn_sinks_client_console_sink_included
+ #endinput
+#endif
+#define _log_for_sourcepawn_sinks_client_console_sink_included
+
+#pragma newdecls required
+#pragma semicolon 1
+
+#include <log4sp_empty/sinks/sink>
+
+
+typeset ClientConsoleSinkFilter
+{
+    function Action (int client);
+    function Action (int client, const char[] name, LogLevel lvl);
+    function Action (int client, const char[] name, LogLevel lvl, const char[] msg);
+};
+
+
+
+methodmap ClientConsoleSinkST < Sink
+{
+    public ClientConsoleSinkST() { return view_as<ClientConsoleSinkST>(INVALID_HANDLE); }
+
+    public void SetFilter(ClientConsoleSinkFilter filter) {}
+}
+
+
+methodmap ClientConsoleSinkMT < Sink
+{
+    public ClientConsoleSinkMT() { return view_as<ClientConsoleSinkMT>(INVALID_HANDLE); }
+
+    public void SetFilter(ClientConsoleSinkFilter filter) {}
+}

--- a/sourcemod/scripting/include/log4sp_empty/sinks/daily_file_sink.inc
+++ b/sourcemod/scripting/include/log4sp_empty/sinks/daily_file_sink.inc
@@ -1,0 +1,25 @@
+#if defined _log_for_sourcepawn_sinks_daily_file_sink_included
+ #endinput
+#endif
+#define _log_for_sourcepawn_sinks_daily_file_sink_included
+
+#pragma newdecls required
+#pragma semicolon 1
+
+#include <log4sp_empty/sinks/sink>
+
+
+methodmap DailyFileSinkST < Sink
+{
+    public DailyFileSinkST(const char[] file, int rotationHour=0, int rotationMinute=0, bool truncate=false, int maxFiles=0) { return view_as<DailyFileSinkST>(INVALID_HANDLE); }
+
+    public void GetFilename(char[] buffer, int maxlength) {}
+}
+
+
+methodmap DailyFileSinkMT < Sink
+{
+    public DailyFileSinkMT(const char[] file, int rotationHour=0, int rotationMinute=0, bool truncate=false, int maxFiles=0) { return view_as<DailyFileSinkMT>(INVALID_HANDLE); }
+
+    public void GetFilename(char[] buffer, int maxlength) {}
+}

--- a/sourcemod/scripting/include/log4sp_empty/sinks/rotating_file_sink.inc
+++ b/sourcemod/scripting/include/log4sp_empty/sinks/rotating_file_sink.inc
@@ -1,0 +1,29 @@
+#if defined _log_for_sourcepawn_sinks_rotating_file_sink_included
+ #endinput
+#endif
+#define _log_for_sourcepawn_sinks_rotating_file_sink_included
+
+#pragma newdecls required
+#pragma semicolon 1
+
+#include <log4sp_empty/sinks/sink>
+
+
+methodmap RotatingFileSinkST < Sink
+{
+    public RotatingFileSinkST(const char[] file, const int maxFileSize, const int maxFiles, bool rotateOnOpen=false) { return view_as<RotatingFileSinkST>(INVALID_HANDLE); }
+
+    public void GetFilename(char[] buffer, int maxlength) {}
+
+    public void CalcFilename(const char[] file, int index, char[] buffer, int maxlength) {}
+}
+
+
+methodmap RotatingFileSinkMT < Sink
+{
+    public RotatingFileSinkMT(const char[] file, const int maxFileSize, const int maxFiles, bool rotateOnOpen=false) { return view_as<RotatingFileSinkMT>(INVALID_HANDLE); }
+
+    public void GetFilename(char[] buffer, int maxlength) {}
+
+    public void CalcFilename(const char[] file, int index, char[] buffer, int maxlength) {}
+}

--- a/sourcemod/scripting/include/log4sp_empty/sinks/server_console_sink.inc
+++ b/sourcemod/scripting/include/log4sp_empty/sinks/server_console_sink.inc
@@ -1,0 +1,21 @@
+#if defined _log_for_sourcepawn_sinks_server_console_sink_included
+ #endinput
+#endif
+#define _log_for_sourcepawn_sinks_server_console_sink_included
+
+#pragma newdecls required
+#pragma semicolon 1
+
+#include <log4sp_empty/sinks/sink>
+
+
+methodmap ServerConsoleSinkST < Sink
+{
+    public ServerConsoleSinkST() { return view_as<ServerConsoleSinkST>(INVALID_HANDLE); }
+}
+
+
+methodmap ServerConsoleSinkMT < Sink
+{
+    public ServerConsoleSinkMT() { return view_as<ServerConsoleSinkMT>(INVALID_HANDLE); }
+}

--- a/sourcemod/scripting/include/log4sp_empty/sinks/sink.inc
+++ b/sourcemod/scripting/include/log4sp_empty/sinks/sink.inc
@@ -1,0 +1,35 @@
+#if defined _log_for_sourcepawn_sinks_sink_included
+ #endinput
+#endif
+#define _log_for_sourcepawn_sinks_sink_included
+
+#pragma newdecls required
+#pragma semicolon 1
+
+#include <log4sp_empty/common>
+
+
+methodmap Sink < Handle
+{
+    public LogLevel GetLevel() { return LogLevel_Off; }
+
+    public void SetLevel(LogLevel lvl) {}
+
+    public void SetPattern(const char[] pattern) {}
+
+    public bool ShouldLog(LogLevel lvl) { return false; }
+
+    public void Log(const char[] name, LogLevel lvl, const char[] msg) {}
+    public void LogAmxTpl(const char[] name, LogLevel lvl, const char[] fmt, any ...) {}
+    // public void LogFmtTpl(LogLevel lvl, const char[] fmt, any ...) {}
+
+    public void LogSrc(const char[] name, LogLevel lvl, const char[] msg) {}
+    public void LogSrcAmxTpl(const char[] name, LogLevel lvl, const char[] fmt, any ...) {}
+    // public void LogSrcFmtTpl(LogLevel lvl, const char[] fmt, any ...) {}
+
+    public void LogLoc(const char[] file, int line, const char[] func, const char[] name, LogLevel lvl, const char[] msg) {}
+    public void LogLocAmxTpl(const char[] file, int line, const char[] func, const char[] name, LogLevel lvl, const char[] fmt, any ...) {}
+    // public void LogLocFmtTpl(const char[] file, int line, const char[] func, LogLevel lvl, const char[] fmt, any ...) {}
+
+    public void Flush() {}
+}


### PR DESCRIPTION
Add macro LOG4SP_NO_LOG to replace all log4sp natives with empty statements.