### PR TITLE
Enhance Logger.ApplyAll

### DIFF
--- a/readme-chi.md
+++ b/readme-chi.md
@@ -155,4 +155,6 @@ VM Ubuntu 配置: 1 CPU + 8 核心 + 8 GB 内存
 
 - Fyren, nosoop, Deathreus 为拓展管理 Sink Handle 提供了解决思路
 
+- [blueblur0730](https://github.com/blueblur0730), Digby 帮助改进了遍历操作所有 logger
+
 如有遗漏，请联系我

--- a/readme.md
+++ b/readme.md
@@ -158,5 +158,7 @@ Test case: [benchmark-sm-logging.sp](./sourcemod/scripting/benchmark-sm-logging.
 
 - Fyren, nosoop, Deathreus provides solution for managing the Sink Handle
 
+- [blueblur0730](https://github.com/blueblur0730), Digby helped improve the traversal operation of all loggers
+
 If I missed anyone, please contact me.
 

--- a/sourcemod/scripting/include/log4sp/logger.inc
+++ b/sourcemod/scripting/include/log4sp/logger.inc
@@ -192,6 +192,13 @@ methodmap Logger < Handle
     public native int GetName(char[] buffer, int maxlen);
 
     /**
+     * Gets the length of the logger name.
+     *
+     * @return          Length of the logger name string.
+     */
+    public native int GetNameLength();
+
+    /**
      * Gets the logger log level.
      *
      * @return          The logger log level.

--- a/sourcemod/scripting/include/log4sp/logger.inc
+++ b/sourcemod/scripting/include/log4sp/logger.inc
@@ -70,25 +70,6 @@ methodmap Logger < Handle
     public static native Logger Get(const char[] name);
 
     /**
-     * Gets all logger handls.
-     *
-     * @param buffer    Buffer to store all logger handles.
-     * @param maxlen    Maximum length of the buffer.
-     * @return          The number of logger handles written to the buffer.
-     */
-    public static native int GetLoggers(Logger[] buffer, int maxlen);
-
-    /**
-     * Gets all logger names.
-     *
-     * @param buffer            Buffer to store all logger names.
-     * @param maxStrings        Number of string buffers (first dimension size).
-     * @param maxStringLength   Maximum length of each string buffer.
-     * @return                  The number of logger names written to the buffer.
-     */
-    public static native int GetNames(char[][] buffer, int maxStrings, int maxStringLenth);
-
-    /**
      * Create a logger handle that outputs to the server console.
      *
      * @param name      The name of the new logger.

--- a/sourcemod/scripting/include/log4sp/logger.inc
+++ b/sourcemod/scripting/include/log4sp/logger.inc
@@ -42,6 +42,7 @@ typeset LoggerErrorHandler
 typeset LoggerApplyAllCallback
 {
     function void (Logger logger);
+    function void (Logger logger, any data);
 };
 
 
@@ -68,6 +69,15 @@ methodmap Logger < Handle
      * @return          Logger handle or INVALID_HANDLE if the logger name does not exist.
      */
     public static native Logger Get(const char[] name);
+
+    /**
+     * Apply a user defined function on all loggers.
+     *
+     * @param callback  A callback that apply a user defined function on all loggers.
+     * @param data      Extra data value to pass to the callback.
+     * @error           Invalid apply all callback.
+     */
+    public static native void ApplyAll(LoggerApplyAllCallback callback, any data = 0);
 
     /**
      * Create a logger handle that outputs to the server console.
@@ -171,14 +181,6 @@ methodmap Logger < Handle
         int maxFiles = 0,
         bool async = false,
         AsyncOverflowPolicy policy = AsyncOverflowPolicy_Block);
-
-    /**
-     * Apply a user defined function on all loggers.
-     *
-     * @param callback  A callback that apply a user defined function on all loggers.
-     * @error           Invalid apply all callback.
-     */
-    public static native void ApplyAll(LoggerApplyAllCallback callback);
 
     /**
      * Gets the logger name.

--- a/sourcemod/scripting/include/log4sp/logger.inc
+++ b/sourcemod/scripting/include/log4sp/logger.inc
@@ -70,6 +70,25 @@ methodmap Logger < Handle
     public static native Logger Get(const char[] name);
 
     /**
+     * Gets all logger handls.
+     *
+     * @param buffer    Buffer to store all logger handles.
+     * @param maxlen    Maximum length of the buffer.
+     * @return          The number of logger handles written to the buffer.
+     */
+    public static native int GetLoggers(Logger[] buffer, int maxlen);
+
+    /**
+     * Gets all logger names.
+     *
+     * @param buffer            Buffer to store all logger names.
+     * @param maxStrings        Number of string buffers (first dimension size).
+     * @param maxStringLength   Maximum length of each string buffer.
+     * @return                  The number of logger names written to the buffer.
+     */
+    public static native int GetNames(char[][] buffer, int maxStrings, int maxStringLenth);
+
+    /**
      * Create a logger handle that outputs to the server console.
      *
      * @param name      The name of the new logger.

--- a/sourcemod/scripting/include/log4sp_no_ext/logger.inc
+++ b/sourcemod/scripting/include/log4sp_no_ext/logger.inc
@@ -63,6 +63,10 @@ methodmap Logger < Handle
         return 0;
     }
 
+    public int GetNameLength() {
+        return 0;
+    }
+
     public LogLevel GetLevel() {
         return LogLevel_Info;
     }

--- a/sourcemod/scripting/include/log4sp_no_ext/logger.inc
+++ b/sourcemod/scripting/include/log4sp_no_ext/logger.inc
@@ -32,6 +32,14 @@ methodmap Logger < Handle
         return view_as<Logger>(INVALID_HANDLE);
     }
 
+    public static int GetLoggers(Logger[] buffer, int maxlen) {
+        return 0;
+    }
+
+    public static int GetNames(char[][] buffer, int maxStrings, int maxStringLenth) {
+        return 0;
+    }
+
     public static Logger CreateServerConsoleLogger(const char[] name, bool async = false, AsyncOverflowPolicy policy = AsyncOverflowPolicy_Block) {
         return view_as<Logger>(INVALID_HANDLE);
     }

--- a/sourcemod/scripting/include/log4sp_no_ext/logger.inc
+++ b/sourcemod/scripting/include/log4sp_no_ext/logger.inc
@@ -18,6 +18,7 @@ typeset LoggerErrorHandler
 typeset LoggerApplyAllCallback
 {
     function void (Logger logger);
+    function void (Logger logger, any data);
 };
 
 static char __message[2048];
@@ -31,6 +32,8 @@ methodmap Logger < Handle
     public static Logger Get(const char[] name) {
         return view_as<Logger>(INVALID_HANDLE);
     }
+
+    public static void ApplyAll(LoggerApplyAllCallback callback, any data = 0) {}
 
     public static Logger CreateServerConsoleLogger(const char[] name, bool async = false, AsyncOverflowPolicy policy = AsyncOverflowPolicy_Block) {
         return view_as<Logger>(INVALID_HANDLE);
@@ -55,8 +58,6 @@ methodmap Logger < Handle
     public static Logger CreateDailyFileLogger(const char[] name, const char[] file, int hour = 0, int minute = 0, bool truncate = false, int maxFiles = 0, bool async = false, AsyncOverflowPolicy policy = AsyncOverflowPolicy_Block) {
         return view_as<Logger>(INVALID_HANDLE);
     }
-
-    public static void ApplyAll(LoggerApplyAllCallback callback) {}
 
     public int GetName(char[] buffer, int maxlen) {
         return 0;

--- a/sourcemod/scripting/include/log4sp_no_ext/logger.inc
+++ b/sourcemod/scripting/include/log4sp_no_ext/logger.inc
@@ -32,14 +32,6 @@ methodmap Logger < Handle
         return view_as<Logger>(INVALID_HANDLE);
     }
 
-    public static int GetLoggers(Logger[] buffer, int maxlen) {
-        return 0;
-    }
-
-    public static int GetNames(char[][] buffer, int maxStrings, int maxStringLenth) {
-        return 0;
-    }
-
     public static Logger CreateServerConsoleLogger(const char[] name, bool async = false, AsyncOverflowPolicy policy = AsyncOverflowPolicy_Block) {
         return view_as<Logger>(INVALID_HANDLE);
     }

--- a/sourcemod/scripting/testsuite/log4sp-test.sp
+++ b/sourcemod/scripting/testsuite/log4sp-test.sp
@@ -372,12 +372,12 @@ void ApplyAll()
 
     // 获取所有 logger 名称
     const int blocksize = 1024;
-    char buffer[blocksize];
     ArrayList names = new ArrayList(blocksize);
 
     Logger.ApplyAll(ApplyAll_GetNames, names);
     for (int i = 0; i < names.Length; ++i)
     {
+        char buffer[blocksize];
         names.GetString(i, buffer, sizeof(buffer));
         PrintToServer("[%d/%d] name: %s", i, names.Length, buffer);
     }
@@ -399,8 +399,10 @@ void LogToSM(const char[] msg)
 
 void ApplyAll_GetNames(Logger logger, ArrayList names)
 {
-    char buffer[1024];
-    logger.GetName(buffer, sizeof(buffer));
+    int size = logger.GetNameLength() + 1;
+    char[] buffer = new char[size];
+
+    logger.GetName(buffer, size);
     names.PushString(buffer);
-    // PrintToServer("name = %s", buffer);
+    // PrintToServer("length = %2d | name = %s", size, buffer);
 }

--- a/sourcemod/scripting/testsuite/log4sp-test.sp
+++ b/sourcemod/scripting/testsuite/log4sp-test.sp
@@ -82,10 +82,6 @@ Action CB_CMD(int client, int args)
 
     ApplyAll();
 
-    GetNames();
-
-    GetLoggers();
-
     return Plugin_Handled;
 }
 
@@ -381,28 +377,4 @@ void ApplyAll_LogSomeMessage(Logger logger)
 void LogToSM(const char[] msg)
 {
     LogError(msg);
-}
-
-void GetNames()
-{
-    char names[1024][1024];
-    int len = Logger.GetNames(names, sizeof(names), sizeof(names[]));
-
-    for (int i = 0; i< len; ++i)
-    {
-        PrintToServer("Length: %d | Index: %d | Name: %s", len, i, names[i]);
-    }
-}
-
-void GetLoggers()
-{
-    Logger loggers[1024];
-    int len = Logger.GetLoggers(loggers, sizeof(loggers));
-
-    char buffer[1024];
-    for (int i = 0; i< len; ++i)
-    {
-        loggers[i].GetName(buffer, sizeof(buffer));
-        PrintToServer("Length: %d | Index: %d | Name: %s", len, i, buffer);
-    }
 }

--- a/sourcemod/scripting/testsuite/log4sp-test.sp
+++ b/sourcemod/scripting/testsuite/log4sp-test.sp
@@ -82,6 +82,10 @@ Action CB_CMD(int client, int args)
 
     ApplyAll();
 
+    GetNames();
+
+    GetLoggers();
+
     return Plugin_Handled;
 }
 
@@ -377,4 +381,28 @@ void ApplyAll_LogSomeMessage(Logger logger)
 void LogToSM(const char[] msg)
 {
     LogError(msg);
+}
+
+void GetNames()
+{
+    char names[1024][1024];
+    int len = Logger.GetNames(names, sizeof(names), sizeof(names[]));
+
+    for (int i = 0; i< len; ++i)
+    {
+        PrintToServer("Length: %d | Index: %d | Name: %s", len, i, names[i]);
+    }
+}
+
+void GetLoggers()
+{
+    Logger loggers[1024];
+    int len = Logger.GetLoggers(loggers, sizeof(loggers));
+
+    char buffer[1024];
+    for (int i = 0; i< len; ++i)
+    {
+        loggers[i].GetName(buffer, sizeof(buffer));
+        PrintToServer("Length: %d | Index: %d | Name: %s", len, i, buffer);
+    }
 }

--- a/sourcemod/scripting/testsuite/log4sp-test.sp
+++ b/sourcemod/scripting/testsuite/log4sp-test.sp
@@ -353,6 +353,7 @@ void TestNullSink()
 
 void StaticFactory()
 {
+    PrintToServer("========== Test Static Factory ==========");
     Logger log = Logger.CreateClientChatLogger("test-factory-client-chat");
     log.Fatal("This is a ClientChatLogger");
     delete log;
@@ -360,11 +361,28 @@ void StaticFactory()
     log = Logger.CreateClientConsoleLogger("test-factory-client-console");
     log.Fatal("This is a ClientConsoleLogger");
     delete log;
+    PrintToServer("========== Test Static Factory End ==========");
 }
 
 void ApplyAll()
 {
+    PrintToServer("========== Test Apply All ==========");
+    // 使用所有 logger 输出一条日志
     Logger.ApplyAll(ApplyAll_LogSomeMessage);
+
+    // 获取所有 logger 名称
+    const int blocksize = 1024;
+    char buffer[blocksize];
+    ArrayList names = new ArrayList(blocksize);
+
+    Logger.ApplyAll(ApplyAll_GetNames, names);
+    for (int i = 0; i < names.Length; ++i)
+    {
+        names.GetString(i, buffer, sizeof(buffer));
+        PrintToServer("[%d/%d] name: %s", i, names.Length, buffer);
+    }
+    delete names;
+    PrintToServer("========== Test Apply All End ==========");
 }
 
 void ApplyAll_LogSomeMessage(Logger logger)
@@ -377,4 +395,12 @@ void ApplyAll_LogSomeMessage(Logger logger)
 void LogToSM(const char[] msg)
 {
     LogError(msg);
+}
+
+void ApplyAll_GetNames(Logger logger, ArrayList names)
+{
+    char buffer[1024];
+    logger.GetName(buffer, sizeof(buffer));
+    names.PushString(buffer);
+    // PrintToServer("name = %s", buffer);
 }

--- a/src/natives/logger.cpp
+++ b/src/natives/logger.cpp
@@ -91,57 +91,6 @@ static cell_t Get(IPluginContext *ctx, const cell_t *params)
 }
 
 /**
- * public static native int GetLoggers(Logger[] buffer, int maxlen);
- */
-static cell_t GetLoggers(IPluginContext *ctx, const cell_t *params)
-{
-    cell_t *buffer;
-    ctx->LocalToPhysAddr(params[1], &buffer);
-
-    auto maxlen = static_cast<int>(params[2]);
-
-    std::vector<Handle_t> handles;
-    log4sp::logger_handler::instance().apply_all(
-        [&](const Handle_t handle) {
-            handles.emplace_back(handle);
-        }
-    );
-
-    int size = handles.size();
-    for (int i = 0; i < maxlen && i < size; ++i)
-    {
-        buffer[i] = handles[i];
-    }
-
-    return std::min(maxlen, size);
-}
-
-/**
- * public static native int GetNames(char[][] buffer, int maxStrings, int maxStringLenth);
- */
-static cell_t GetNames(IPluginContext *ctx, const cell_t *params)
-{
-    cell_t *buffer;
-    ctx->LocalToPhysAddr(params[1], &buffer);
-
-    auto maxStrings = static_cast<int>(params[2]);
-    auto maxStringLenth = static_cast<int>(params[3]);
-
-    std::vector<std::string> names = log4sp::logger_handler::instance().get_all_logger_names();
-
-    int counter = 0;
-    for (auto &name : names)
-    {
-        if (counter >= maxStrings)
-            break;
-
-        ctx->StringToLocalUTF8(buffer[counter++], maxStringLenth, name.c_str(), nullptr);
-    }
-
-    return counter;
-}
-
-/**
  * public static native Logger CreateServerConsoleLogger(const char[] name, bool async = false, AsyncOverflowPolicy policy = AsyncOverflowPolicy_Block);
  */
 static cell_t CreateServerConsoleLogger(IPluginContext *ctx, const cell_t *params)
@@ -1950,8 +1899,6 @@ const sp_nativeinfo_t LoggerNatives[] =
 {
     {"Logger.Logger",                           Logger},
     {"Logger.Get",                              Get},
-    {"Logger.GetLoggers",                       GetLoggers},
-    {"Logger.GetNames",                         GetNames},
     {"Logger.CreateServerConsoleLogger",        CreateServerConsoleLogger},
     {"Logger.CreateBaseFileLogger",             CreateBaseFileLogger},
     {"Logger.CreateClientChatLogger",           CreateClientChatLogger},

--- a/src/natives/logger.cpp
+++ b/src/natives/logger.cpp
@@ -503,6 +503,26 @@ static cell_t GetName(IPluginContext *ctx, const cell_t *params)
 }
 
 /**
+ * public native int GetNameLength();
+ */
+static cell_t GetNameLength(IPluginContext *ctx, const cell_t *params)
+{
+    auto handle = static_cast<Handle_t>(params[1]);
+
+    HandleSecurity security{ctx->GetIdentity(), myself->GetIdentity()};
+    HandleError error;
+
+    std::shared_ptr<log4sp::logger_proxy> logger = log4sp::logger_handler::instance().read_handle(handle, &security, &error);
+    if (logger == nullptr)
+    {
+        ctx->ReportError("Invalid logger handle %x (error: %d)", handle, error);
+        return 0;
+    }
+
+    return logger->name().length();
+}
+
+/**
  * public native LogLevel GetLevel();
  */
 static cell_t GetLevel(IPluginContext *ctx, const cell_t *params)
@@ -1911,6 +1931,7 @@ const sp_nativeinfo_t LoggerNatives[] =
     {"Logger.ApplyAll",                         ApplyAll},
 
     {"Logger.GetName",                          GetName},
+    {"Logger.GetNameLength",                    GetNameLength},
     {"Logger.GetLevel",                         GetLevel},
     {"Logger.SetLevel",                         SetLevel},
     {"Logger.SetPattern",                       SetPattern},

--- a/src/natives/logger.cpp
+++ b/src/natives/logger.cpp
@@ -91,6 +91,49 @@ static cell_t Get(IPluginContext *ctx, const cell_t *params)
 }
 
 /**
+ * public static native void ApplyAll(LoggerApplyCallback callback);
+ *
+ * function void (Logger logger, any data = 0);
+ */
+static cell_t ApplyAll(IPluginContext *ctx, const cell_t *params)
+{
+    auto funcID   = static_cast<funcid_t>(params[1]);
+    auto function = ctx->GetFunctionById(funcID);
+    if (function == nullptr)
+    {
+        ctx->ReportError("Invalid apply all function. (funcID: %d)", static_cast<int>(funcID));
+        return 0;
+    }
+
+    IChangeableForward *forward = forwards->CreateForwardEx(nullptr, ET_Ignore, 2, nullptr, Param_Cell, Param_Cell);
+    if (forward == nullptr)
+    {
+        ctx->ReportError("SM error! Create apply all forward failure.");
+        return 0;
+    }
+
+    if (!forward->AddFunction(function))
+    {
+        forwards->ReleaseForward(forward);
+        ctx->ReportError("SM error! Adding error handler function failed.");
+        return 0;
+    }
+
+    auto data = params[2];
+
+    log4sp::logger_handler::instance().apply_all(
+        [forward, data](const Handle_t handle) {
+            forward->PushCell(handle);
+            forward->PushCell(data);
+            forward->Execute();
+        }
+    );
+
+    forwards->ReleaseForward(forward);
+    return 0;
+}
+
+/**
  * public static native Logger CreateServerConsoleLogger(const char[] name, bool async = false, AsyncOverflowPolicy policy = AsyncOverflowPolicy_Block);
  */
 static cell_t CreateServerConsoleLogger(IPluginContext *ctx, const cell_t *params)
@@ -435,46 +478,6 @@ static cell_t CreateDailyFileLogger(IPluginContext *ctx, const cell_t *params)
 
         return handle;
     }
-}
-
-/**
- * public static native void ApplyAll(LoggerApplyCallback callback);
- *
- * function void (Logger logger);
- */
-static cell_t ApplyAll(IPluginContext *ctx, const cell_t *params)
-{
-    auto funcID   = static_cast<funcid_t>(params[1]);
-    auto function = ctx->GetFunctionById(funcID);
-    if (function == nullptr)
-    {
-        ctx->ReportError("Invalid apply callback function id (%X)", static_cast<int>(funcID));
-        return 0;
-    }
-
-    IChangeableForward *forward = forwards->CreateForwardEx(nullptr, ET_Ignore, 1, nullptr, Param_Cell);
-    if (forward == nullptr)
-    {
-        ctx->ReportError("SM error! Could not create apply all forward.");
-        return 0;
-    }
-
-    if (!forward->AddFunction(function))
-    {
-        forwards->ReleaseForward(forward);
-        ctx->ReportError("SM error! Could not add apply all function.");
-        return 0;
-    }
-
-    log4sp::logger_handler::instance().apply_all(
-        [forward](const Handle_t handle) {
-            forward->PushCell(handle);
-            forward->Execute();
-        }
-    );
-
-    forwards->ReleaseForward(forward);
-    return 0;
 }
 
 /**

--- a/src/natives/logger.cpp
+++ b/src/natives/logger.cpp
@@ -91,6 +91,57 @@ static cell_t Get(IPluginContext *ctx, const cell_t *params)
 }
 
 /**
+ * public static native int GetLoggers(Logger[] buffer, int maxlen);
+ */
+static cell_t GetLoggers(IPluginContext *ctx, const cell_t *params)
+{
+    cell_t *buffer;
+    ctx->LocalToPhysAddr(params[1], &buffer);
+
+    auto maxlen = static_cast<int>(params[2]);
+
+    std::vector<Handle_t> handles;
+    log4sp::logger_handler::instance().apply_all(
+        [&](const Handle_t handle) {
+            handles.emplace_back(handle);
+        }
+    );
+
+    int size = handles.size();
+    for (int i = 0; i < maxlen && i < size; ++i)
+    {
+        buffer[i] = handles[i];
+    }
+
+    return std::min(maxlen, size);
+}
+
+/**
+ * public static native int GetNames(char[][] buffer, int maxStrings, int maxStringLenth);
+ */
+static cell_t GetNames(IPluginContext *ctx, const cell_t *params)
+{
+    cell_t *buffer;
+    ctx->LocalToPhysAddr(params[1], &buffer);
+
+    auto maxStrings = static_cast<int>(params[2]);
+    auto maxStringLenth = static_cast<int>(params[3]);
+
+    std::vector<std::string> names = log4sp::logger_handler::instance().get_all_logger_names();
+
+    int counter = 0;
+    for (auto &name : names)
+    {
+        if (counter >= maxStrings)
+            break;
+
+        ctx->StringToLocalUTF8(buffer[counter++], maxStringLenth, name.c_str(), nullptr);
+    }
+
+    return counter;
+}
+
+/**
  * public static native Logger CreateServerConsoleLogger(const char[] name, bool async = false, AsyncOverflowPolicy policy = AsyncOverflowPolicy_Block);
  */
 static cell_t CreateServerConsoleLogger(IPluginContext *ctx, const cell_t *params)
@@ -1899,6 +1950,8 @@ const sp_nativeinfo_t LoggerNatives[] =
 {
     {"Logger.Logger",                           Logger},
     {"Logger.Get",                              Get},
+    {"Logger.GetLoggers",                       GetLoggers},
+    {"Logger.GetNames",                         GetNames},
     {"Logger.CreateServerConsoleLogger",        CreateServerConsoleLogger},
     {"Logger.CreateBaseFileLogger",             CreateBaseFileLogger},
     {"Logger.CreateClientChatLogger",           CreateClientChatLogger},


### PR DESCRIPTION
增强 Logger.ApplyAll 方法，添加了一个数据槽位，方便在代码块内传递和获取数据，而不仅局限于全局变量。

例如:

之前只能这样获取所有 logger 名称

```sourcepawn
ArrayList g_names;

void GetAllLoggerNames()
{
    g_names = new ArrayList(.blocksize = 1024);
    Logger.ApplyAll(ApplyAll_GetAllNames);

    for (int i = 0; i < g_names.Length; ++i)
    {
        char buffer[1024];
        g_names.GetString(i, buffer, sizeof(buffer));
        PrintToServer("[%d/%d] name: %s", i, g_names.Length, buffer);
    }

    delete g_names;
}

void ApplyAll_GetAllNames(Logger logger)
{
    char buffer[1024];
    logger.GetName(buffer, sizeof(buffer));
    g_names.PushString(buffer);
}
```

现在可以在 `GetAllLoggerNames` 的方法体里定义返回值而不是全局

```sourcepawn
void GetAllLoggerNames()
{
    ArrayList names = new ArrayList(.blocksize = 1024);
    Logger.ApplyAll(ApplyAll_GetAllNames, names);

    for (int i = 0; i < names.Length; ++i)
    {
        char buffer[1024];
        names.GetString(i, buffer, sizeof(buffer));
        PrintToServer("[%d/%d] name: %s", i, names.Length, buffer);
    }

    delete names;
}

void ApplyAll_GetAllNames(Logger logger, ArrayList names)
{
    char buffer[1024];
    logger.GetName(buffer, sizeof(buffer));
    names.PushString(buffer);
}
```
