### PR TITLE
fix: Allow entity references for clients with L and N format specifiers

### DIFF
--- a/src/log4sp/common.cpp
+++ b/src/log4sp/common.cpp
@@ -503,7 +503,8 @@ static void AddHex(memory_buf_t &out, unsigned int val, unsigned int width, int 
     }
 }
 
-static bool DescribePlayer(int index, const char **namep, const char **authp, int *useridp) noexcept {
+static bool DescribePlayer(int entRef, const char **namep, const char **authp, int *useridp) noexcept {
+    int index{gamehelpers->ReferenceToIndex(entRef)};
     SourceMod::IGamePlayer *player{playerhelpers->GetGamePlayer(index)};
     if (!player || !player->IsConnected()) {
         return false;


### PR DESCRIPTION
Related to: https://github.com/alliedmodders/sourcemod/issues/2243